### PR TITLE
Fixed a null error for getLargestId.

### DIFF
--- a/src/main/java/dataAccess/FlashcardSetDataAccess.java
+++ b/src/main/java/dataAccess/FlashcardSetDataAccess.java
@@ -127,6 +127,9 @@ public class FlashcardSetDataAccess implements IFlashcardSetDataAccess{
     }
 
     private int getLargestId(){
+        if (flashcardSets.size() == 0) {
+            return -1;
+        }
         Set<Integer> ids = flashcardSets.keySet();
         return max(ids);
     }


### PR DESCRIPTION
Tested manually with empty file when creating a flashcard set.