### PR TITLE
Addressed warnings in create/delete flashcard sets

### DIFF
--- a/src/main/java/create_flashcard_set_use_case/CreationScreen.java
+++ b/src/main/java/create_flashcard_set_use_case/CreationScreen.java
@@ -1,7 +1,6 @@
 package create_flashcard_set_use_case;
 
 import login_and_signup_use_case.UserLoginResponseModel;
-import view.Screen;
 
 import javax.swing.*;
 import java.awt.*;
@@ -11,13 +10,18 @@ import java.util.Objects;
 
 // Frameworks/Drivers (Blue) layer
 
-public class CreationScreen extends Screen implements ActionListener {
+/**
+ * The flashcard set creation screen.
+ *
+ * @author Edward Ishii
+ */
+public class CreationScreen extends JFrame implements ActionListener {
     /**
-     * The title of the flashcard set chosen by the user
+     * The title of the flashcard set chosen by the user.
      */
     JTextField title = new JTextField(15);
     /**
-     * The description of the flashcard set
+     * The description of the flashcard set.
      */
     JTextField description = new JTextField(15);
 //    /**
@@ -26,10 +30,13 @@ public class CreationScreen extends Screen implements ActionListener {
 //    JTextField username = new JTextField(15);
 
     /**
-     * The controller
+     * The controller.
      */
     FlashcardSetController flashcardSetController;
 
+    /**
+     * The user.
+     */
     UserLoginResponseModel user;
 
     private boolean privateSelected;  // for public or private status of flashcard set
@@ -93,10 +100,10 @@ public class CreationScreen extends Screen implements ActionListener {
             privateSelected = !privateSelected;  // toggle every time clicked
         } else {
             try {
-                flashcardSetController.create(title.getText(), description.getText(),
-                        privateSelected, user.getSignedInUsername());
+                FlashcardSetResponseModel responseModel = flashcardSetController.create(title.getText(),
+                        description.getText(), privateSelected, user.getSignedInUsername());
                 JOptionPane.showMessageDialog(this,
-                        String.format("Flashcard Set: [%s] created.", title.getText()));
+                        String.format("Flashcard Set: [%s] has been created.", responseModel.getFs().getTitle()));
                 this.dispose();  // exit creation screen
             } catch (FlashcardSetCreationFailed e) {
                 JOptionPane.showMessageDialog(this, e.getMessage());

--- a/src/main/java/delete_flashcard_set_use_case/DelFlashcardSetInteractor.java
+++ b/src/main/java/delete_flashcard_set_use_case/DelFlashcardSetInteractor.java
@@ -3,8 +3,6 @@ package delete_flashcard_set_use_case;
 // Use case (Red) layer
 
 import data_access.DBGateway;
-import data_access.IFlashcardDataAccess;
-import data_access.IFlashcardSetDataAccess;
 
 /**
  * [Feature: Deleting a Flashcard Set]
@@ -21,8 +19,7 @@ import data_access.IFlashcardSetDataAccess;
 public class DelFlashcardSetInteractor implements DelFlashcardSetInputBoundary {
 
     DBGateway dbGateway;
-    IFlashcardSetDataAccess flashcardSetDataAccess;  // for testing
-    IFlashcardDataAccess flashcardDataAccess;  // for testing
+
     DelFlashcardSetOutputBoundary outputBoundary;
 
     public DelFlashcardSetInteractor(DBGateway dbGateway, DelFlashcardSetOutputBoundary outputBoundary) {

--- a/src/main/java/delete_flashcard_set_use_case/DeletionScreen.java
+++ b/src/main/java/delete_flashcard_set_use_case/DeletionScreen.java
@@ -1,9 +1,7 @@
 package delete_flashcard_set_use_case;
 
-
 import data_access.DBGateway;
 import login_and_signup_use_case.UserLoginResponseModel;
-import view.Screen;
 
 import javax.swing.*;
 import java.awt.*;
@@ -13,18 +11,30 @@ import java.util.Objects;
 
 // Frameworks/Drivers (Blue) layer
 
-public class DeletionScreen extends Screen implements ActionListener {
+/**
+ * The flashcard set deletion screen.
+ *
+ * @author Edward Ishii
+ */
+public class DeletionScreen extends JFrame implements ActionListener {
     /**
-     * The id of the flashcard set to be deleted
+     * The id of the flashcard set to be deleted.
      */
     int flashcardSetID;
 
+    /**
+     * The user.
+     */
     UserLoginResponseModel user;
 
     /**
-     * The controller
+     * The controller.
      */
     DelFlashcardSetController controller;
+
+    /**
+     * The database gateway.
+     */
     DBGateway gateway;
 
 //    /**
@@ -37,7 +47,7 @@ public class DeletionScreen extends Screen implements ActionListener {
      */
     public DeletionScreen(int flashcardSetID, DelFlashcardSetController controller, UserLoginResponseModel user,
                           DBGateway gateway) {
-        this.user=user;
+        this.user = user;
         this.flashcardSetID = flashcardSetID;
         this.controller = controller;
         this.gateway = gateway;
@@ -78,19 +88,16 @@ public class DeletionScreen extends Screen implements ActionListener {
         // Exit deletion screen if user cancels deletion
         if (Objects.equals(evt.getActionCommand(), "Cancel")) {
             this.dispose();
-        }
-
-        else {  // Delete was pressed
+        } else {  // Delete was pressed
 //            try {
 //                int id = Integer.parseInt(flashcardSetID.getText());  // check input is an integer
 
             // Ask for confirmation
             String title;
             // Admin deletion
-            if (user.getFlashcardSets().get(flashcardSetID) == null){
-                title =  gateway.getFlashcardSet(flashcardSetID).getTitle();
-            }
-            else{
+            if (user.getFlashcardSets().get(flashcardSetID) == null) {
+                title = gateway.getFlashcardSet(flashcardSetID).getTitle();
+            } else {
                 // User deletion
                 title = user.getFlashcardSets().get(flashcardSetID)[0];
             }
@@ -101,8 +108,9 @@ public class DeletionScreen extends Screen implements ActionListener {
                     "Confirmation", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
             if (confirmation == 0) {
                 try {
-                    controller.delete(flashcardSetID);
-                    JOptionPane.showMessageDialog(this, title + " has been deleted.");
+                    DelFlashcardSetResponseModel responseModel = controller.delete(flashcardSetID);
+                    responseModel.setMessage(title + " has been deleted.");
+                    JOptionPane.showMessageDialog(this, responseModel.getMessage());
                     this.dispose();  // exit deletion screen
                 } catch (FlashcardSetNotFound e) {
                     JOptionPane.showMessageDialog(this, e.getMessage());

--- a/src/test/java/create_flashcard_set_use_case/FlashcardSetInteractorTest.java
+++ b/src/test/java/create_flashcard_set_use_case/FlashcardSetInteractorTest.java
@@ -65,7 +65,7 @@ public class FlashcardSetInteractorTest {
     }
 
     @Test
-    public void testMissingTitleException() throws FlashcardSetCreationFailed {
+    public void testMissingTitleException() {
         // Create a mock user input with no title
         FlashcardSetRequestModel requestModel = new FlashcardSetRequestModel("",
                 "Final Exam Review", false, "uncle_bob69");
@@ -92,14 +92,14 @@ public class FlashcardSetInteractorTest {
         try {
             interactor.create(requestModel);  // no title should go immediately to catch block (i.e., pass test)
             assert (false);  // if title is included, then this line is reached and test fails
-        } catch (FlashcardSetCreationFailed e) {
+        } catch (FlashcardSetCreationFailed ignored) {
 
         }
 
     }
 
     @Test
-    public void testMissingDescriptionException() throws FlashcardSetCreationFailed {
+    public void testMissingDescriptionException() {
         // Create a mock user input with no description
         FlashcardSetRequestModel requestModel = new FlashcardSetRequestModel("CSC207",
                 "", false, "uncle_bob69");
@@ -126,14 +126,14 @@ public class FlashcardSetInteractorTest {
         try {
             interactor.create(requestModel);
             assert (false);
-        } catch (FlashcardSetCreationFailed e) {
+        } catch (FlashcardSetCreationFailed ignored) {
 
         }
 
     }
 
     @Test
-    public void testMissingUsernameException() throws FlashcardSetCreationFailed {
+    public void testMissingUsernameException() {
         // Create a mock user input with no username
         FlashcardSetRequestModel requestModel = new FlashcardSetRequestModel("CSC207",
                 "Final Exam Review", false, "");
@@ -160,7 +160,7 @@ public class FlashcardSetInteractorTest {
         try {
             interactor.create(requestModel);
             assert (false);
-        } catch (FlashcardSetCreationFailed e) {
+        } catch (FlashcardSetCreationFailed ignored) {
 
         }
 

--- a/src/test/java/delete_flashcard_set_use_case/DelFlashcardSetInteractorTest.java
+++ b/src/test/java/delete_flashcard_set_use_case/DelFlashcardSetInteractorTest.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * [Feature: Deleting a Flashcard Set]
@@ -27,13 +26,17 @@ import static org.junit.jupiter.api.Assertions.fail;
  * - if it exists, ask for confirmation to delete from the user
  * - when a flashcard set is deleted, all flashcards contained within are deleted
  * - notify successful deletion of flashcard set to the user
+ *
+ * @author Edward Ishii
  */
-
 public class DelFlashcardSetInteractorTest {
 
     IFlashcardSetDataAccess flashcardSetRepo;
     IFlashcardDataAccess flashcardRepo;
 
+    /**
+     * The setup for testing deletion, i.e., create and populate mock flashcard set and flashcard databases.
+     */
     @BeforeEach
     public void setup() {
         // Create a mock flashcard set repository
@@ -44,7 +47,7 @@ public class DelFlashcardSetInteractorTest {
 
         // Populate flashcardRepo
         FlashcardDsRequestModel fc1 = new FlashcardDsRequestModel("SOLID", "Single responsibility, " +
-                "Open/closed, Liskov substitution, Interface segregation, Dependency inversion", LocalDateTime.now(),
+                "Open/closed, Liskov substitution, Interface segragation, Dependency inversion", LocalDateTime.now(),
                 10, 1);
 
         FlashcardDsRequestModel fc2 = new FlashcardDsRequestModel("Bloaters", "too much code",
@@ -84,6 +87,10 @@ public class DelFlashcardSetInteractorTest {
         Assertions.assertEquals(1, flashcardSetRepo.getFlashcardSet(2).getFlashcardIds().size());
     }
 
+    /**
+     * Test that when a flashcard set is deleted, the set is deleted from the flashcard set database, AND all
+     * the associated flashcards within that set is also deleted from the flashcard database.
+     */
     @Test
     public void testDelete() {
         // Create mock input
@@ -121,27 +128,31 @@ public class DelFlashcardSetInteractorTest {
         Assertions.assertEquals("Language", flashcardRepo.getFlashcard(30).getTerm());
     }
 
+    /**
+     * Test that the proper exception is thrown when the id of the flashcard set to be deleted does not exist
+     * within the database.
+     */
     @Test
-    public void testDeleteOnNonExistentFlashcardSet() throws FlashcardSetNotFound {
+    public void testDeleteOnNonExistentFlashcardSet() {
 
         // Mock input with id of a flashcard set that doesn't exist
         DelFlashcardSetRequestModel inputData = new DelFlashcardSetRequestModel(3);
 
 
         // Implement output boundaries to throw an exception
-        DelFlashcardSetOutputBoundary outputBoundary = new DelFlashcardSetOutputBoundary() {
-            @Override
-            public DelFlashcardSetResponseModel prepareSuccessView(String message) {
-                fail("Something went wrong since we are testing for failing deletion.");
-                return null;
-            }
-
-            @Override
-            public DelFlashcardSetResponseModel prepareFailView(String error) throws FlashcardSetNotFound {
-                throw new FlashcardSetNotFound("Flashcard set #" + inputData.getFlashcardSetId()
-                        + "  does not exist.");
-            }
-        };
+//        DelFlashcardSetOutputBoundary outputBoundary = new DelFlashcardSetOutputBoundary() {
+//            @Override
+//            public DelFlashcardSetResponseModel prepareSuccessView(String message) {
+//                fail("Something went wrong since we are testing for failing deletion.");
+//                return null;
+//            }
+//
+//            @Override
+//            public DelFlashcardSetResponseModel prepareFailView(String error) throws FlashcardSetNotFound {
+//                throw new FlashcardSetNotFound("Flashcard set #" + inputData.getFlashcardSetId()
+//                        + "  does not exist.");
+//            }
+//        };
 
         DelFlashcardSetOutputBoundary presenter = new DelFlashcardSetPresenter();
 
@@ -167,8 +178,8 @@ public class DelFlashcardSetInteractorTest {
         // Test part
         try {
             interactor.delete(inputData);  // invalid id should go immediately to catch block (i.e., pass test)
-            assert(false);  // if id exists, then this line is reached and test fails
-        } catch (FlashcardSetNotFound e) {
+            assert (false);  // if id exists, then this line is reached and test fails
+        } catch (FlashcardSetNotFound ignored) {
 
         }
     }


### PR DESCRIPTION
Got rid of all non-weak warnings pertaining to the use cases: create/delete flashcard set.